### PR TITLE
Adding path prefix for tests files in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ On **mocha-test** for use with grunt
 				reporterOptions:{
 				  output : 'unit-tests.xml' // default to ./xunit.xml
 				  useFullFilePath: 'true' // default to 'false'. Uses full test file paths in the report.
+				  pathPrefix: '/custom/root/directory'  // default to null. Add custom path prefix in the report to match sonar configuration.
 				}
 			},
 			src: [

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function (runner, options) {
             file = file.substr(file.indexOf(root) + root.length + 1);
         }
         if (pathPrefix) {
-            file = path.concat(pathPrefix, file);
+            file = path.join(pathPrefix, file);
         }
         stackF = stack[file];
         if (!stackF) {

--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ module.exports = function (runner, options) {
         var file = getFilePath(test);
         if (!useFullFilePath) {
             file = file.substr(file.indexOf(root) + root.length + 1);
-        } else if (pathPrefix) {
+        }
+        if (pathPrefix) {
             file = path.concat(pathPrefix, file);
         }
         stackF = stack[file];

--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ module.exports = function (runner, options) {
         if (options.reporterOptions.useFullFilePath) {
             useFullFilePath = true;
         }
-        if (options.reporterOptions.useFullFilePath) {
-            pathPrefix = options.reporterOptions.useFullFilePath;
+        if (options.reporterOptions.pathPrefix) {
+            pathPrefix = options.reporterOptions.pathPrefix;
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = function (runner, options) {
     var stackF;
     var root = process.cwd();
     var useFullFilePath = false;
+    var pathPrefix;
     var filePath = "./xunit.xml";
 
     //get output file option if any
@@ -23,6 +24,9 @@ module.exports = function (runner, options) {
         }
         if (options.reporterOptions.useFullFilePath) {
             useFullFilePath = true;
+        }
+        if (options.reporterOptions.useFullFilePath) {
+            pathPrefix = options.reporterOptions.useFullFilePath;
         }
     }
 
@@ -39,6 +43,8 @@ module.exports = function (runner, options) {
         var file = getFilePath(test);
         if (!useFullFilePath) {
             file = file.substr(file.indexOf(root) + root.length + 1);
+        } else if (pathPrefix) {
+            file = path.concat(pathPrefix, file);
         }
         stackF = stack[file];
         if (!stackF) {


### PR DESCRIPTION
In our pipeline, we run unit tests in a container. And sends reports files to sonar 
 - coverage with nyc
 - tests results with mocha-sonarqube-reporter

With nyc, we are able to indicate cwd in order to have correct path for sonar.

But we still have a problem with the xunit.xml.
Actually, we have the path relative to the npm cwd : 
`<file path="tests/front.spec.js">`

With the `useFullFilePath` parameter, we have the absolute path in the test container.
`<file path="/work_directory/tests/front.spec.js">`
 
I suggest a simple parameter to add pathPrefix to match sonar configuration.
pathPrefix: "/sonar/project/path";
`<file path="/sonar/project/path/tests/front.spec.js">`

